### PR TITLE
Feature/dockerimage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /script
 RUN /script/test_install_cni_plugins.sh
 
 # In this container we build the plug-ins
-FROM golang:1.11 as build
+FROM golang:1.15 as build
 
 ENV BRANCH_OR_TAG=master
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ FROM busybox
 COPY --from=build /go/src/app/bin /opt/cni/bin
 VOLUME /host/opt/cni/bin
 ADD docker-installer/install_cni_plugins.sh /script/install_cni_plugins.sh
-CMD ['/script/install_cni_plugins.sh','/opt/cni/bin','/host/opt/cni/bin']
+CMD ["/script/install_cni_plugins.sh","/opt/cni/bin","/host/opt/cni/bin"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,23 @@
-FROM golang:1.11.2 as build
+# In this container we test the install script
+FROM busybox as test
+
+ADD docker-installer/install_cni_plugins.sh /script/install_cni_plugins.sh
+ADD docker-installer/test_install_cni_plugins.sh /script/test_install_cni_plugins.sh
+WORKDIR /script
+RUN /script/test_install_cni_plugins.sh
+
+# In this container we build the plug-ins
+FROM golang:1.11 as build
+
+ENV BRANCH_OR_TAG=master
 
 WORKDIR /go/src/app
-COPY . .
+ADD . .
 RUN ./build_linux.sh
 
+# This is the final, minimal container
 FROM busybox
 COPY --from=build /go/src/app/bin /opt/cni/bin
-WORKDIR /opt/cni/bin
-
+VOLUME /host/opt/cni/bin
+ADD docker-installer/install_cni_plugins.sh /script/install_cni_plugins.sh
+CMD ['/script/install_cni_plugins.sh','/opt/cni/bin','/host/opt/cni/bin']

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.11.2 as build
+
+WORKDIR /go/src/app
+COPY . .
+RUN ./build_linux.sh
+
+FROM busybox
+COPY --from=build /go/src/app/bin /opt/cni/bin
+WORKDIR /opt/cni/bin
+

--- a/docker-installer/README.md
+++ b/docker-installer/README.md
@@ -1,0 +1,9 @@
+This scripts are used in the docker image.
+
+The docker image installs the plug-ins to /host/opt/cni/bin which should be bind-mounted to /opt/cni/bin on the host.
+
+The installer-script keeps track of plug-ins it installs and ensures:
+- that no existing plug-ins that have been installed or updated by someone else are overwriten
+- that plug-ins installed by this script are updated if a new version of this image is used
+
+A unit-test shell script for the installer script is part of the docker build process.

--- a/docker-installer/install_cni_plugins.sh
+++ b/docker-installer/install_cni_plugins.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+
+set -e
+
+if [ $# -ne 2 ]; then
+  echo "USAGE: $0 source-dir dest-dir"
+  exit 1
+fi
+
+SRC=$1
+DST=$2
+
+install_cni_plugin() {
+	NAME=$1
+	MD5=$( md5sum $SRC/$NAME | awk '{ print $1 }' )
+	if [ -e $DST/$NAME ]; then
+		if [ ! -e $DST/$NAME.by_cni_installer_image ]; then
+			# The file already exists but there's no marker that
+			# it was installed by this installer -> keep untouched
+			echo "* '$NAME' ignored (exists but not installed by me)"
+			return
+		fi
+		OTHER_MD5=$( md5sum $DST/$NAME | awk '{ print $1 }' )
+		INSTALLED_MD5=$( cat $DST/$NAME.by_cni_installer_image )
+
+		if [ "$OTHER_MD5" != "$INSTALLED_MD5" ]; then
+			# The file was previously installed by this installer
+			# but later changed -> keep untouched
+			echo "* '$NAME' ignored (previously installed by me but changed by someone else)"
+			return
+		fi
+
+		if [ "$OTHER_MD5" == "$MD5" ]; then
+			# The file was previously installed by this installer
+			# and is up-to-date
+			echo "* '$NAME' is up-to-date"
+			return
+		fi
+
+		# The file was previously installed by this installer
+		# but needs an update
+		cp -a $SRC/$NAME $DST/$NAME
+		echo $MD5 > $DST/$NAME.by_cni_installer_image
+		echo "* '$NAME' updated"
+
+	else
+		cp -a $SRC/$NAME $DST/$NAME
+		echo $MD5 > $DST/$NAME.by_cni_installer_image
+		echo "* '$NAME' installed"
+	fi
+}
+
+echo "Installing CNI plug-ins to $DST"
+echo
+
+for FILE in $( find $SRC -maxdepth 1  -type f ); do
+	NAME=$( basename $FILE )
+	install_cni_plugin $NAME
+done

--- a/docker-installer/test_install_cni_plugins.sh
+++ b/docker-installer/test_install_cni_plugins.sh
@@ -1,0 +1,128 @@
+#!/bin/sh
+
+set -e
+
+prepare() {
+	echo
+	echo
+	echo "=== Testing: $1 ==="
+	echo
+	rm -rf test
+	mkdir -p test/src
+	mkdir -p test/dst
+}
+
+assert_file_missing() {
+	FILE=test/dst/$1
+
+	if [ -e $FILE ]; then
+		echo "File $1 exists but must not exist."
+		echo
+		echo "=== Test failed. ==="
+		exit 1
+    fi
+}
+
+assert_file_content() {
+	FILE=test/dst/$1
+
+	if [ ! -e $FILE ]; then
+		echo "Expected file $1 is missing."
+		echo
+		echo "=== Test failed. ==="
+		exit 1
+    fi
+
+	EXPECTED_CONTENT=$2
+	ACTUAL_CONTENT=$( cat $FILE )
+
+	if [ "$EXPECTED_CONTENT" != "$ACTUAL_CONTENT" ]; then
+		echo "File $1 has wrong content"
+		echo "Expected: $EXPECTED_CONTENT"
+		echo "Actual  : $ACTUAL_CONTENT"
+		echo
+		echo "=== Test failed. ==="
+		exit 1
+	fi
+}
+
+
+#############################################################
+
+prepare "Installation if not exists yet"
+
+echo "cni1.0" > test/src/cni1
+./install_cni_plugins.sh test/src test/dst
+
+assert_file_content cni1 "cni1.0"
+assert_file_content cni1.by_cni_installer_image "7ec08d6ee0e5237cb34be4a31d9146c1"
+
+echo
+echo "Test passed."
+
+#############################################################
+
+prepare "Keep when up-to-date"
+
+echo "cni1.0" > test/src/cni1
+./install_cni_plugins.sh test/src test/dst
+echo "cni1.0" > test/src/cni1
+./install_cni_plugins.sh test/src test/dst
+
+assert_file_content cni1 "cni1.0"
+assert_file_content cni1.by_cni_installer_image "7ec08d6ee0e5237cb34be4a31d9146c1"
+
+echo
+echo "Test passed."
+
+#############################################################
+
+prepare "Upgrade when installed by this installer"
+
+echo "cni1.0" > test/src/cni1
+./install_cni_plugins.sh test/src test/dst
+
+echo "cni1.1" > test/src/cni1
+./install_cni_plugins.sh test/src test/dst
+
+assert_file_content cni1 "cni1.1"
+assert_file_content cni1.by_cni_installer_image "286f99e881938508552bb58ea1c2c565"
+
+echo
+echo "Test passed."
+
+#############################################################
+
+prepare "Installed by someone else"
+
+echo "cni1.0" > test/src/cni1
+echo "cni1.other" > test/dst/cni1
+./install_cni_plugins.sh test/src test/dst
+
+assert_file_content cni1 "cni1.other"
+assert_file_missing cni1.by_cni_installer_image
+
+echo
+echo "Test passed."
+
+#############################################################
+
+prepare "Installed by me, altered by someone else"
+
+echo "cni1.0" > test/src/cni1
+./install_cni_plugins.sh test/src test/dst
+
+echo "cni1.other" > test/dst/cni1
+./install_cni_plugins.sh test/src test/dst
+
+assert_file_content cni1 "cni1.other"
+assert_file_content cni1.by_cni_installer_image "7ec08d6ee0e5237cb34be4a31d9146c1"
+
+echo
+echo "Test passed."
+
+#############################################################
+
+
+echo
+echo "All tests passed."


### PR DESCRIPTION
See https://github.com/containernetworking/plugins/pull/245 for discussion.

This PR adds a docker image that installs the cni binaries on a host. We can use this for multus-cni to create a setup that works out-of-the-box.